### PR TITLE
Resolve #31 Update headings

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -2,10 +2,6 @@
     --hx-font-sans: system-ui, sans-serif;
 }
 
-h1 {
-    font-variant: all-small-caps;
-}
-
 strong {
     color: var(--hx-color-primary-400);
 }
@@ -64,12 +60,16 @@ strong {
     line-height: var(--tw-leading,var(--hx-text-5xl--line-height));
     margin-bottom: 1em;
     margin-top: 1em;
+    font-variant: all-small-caps;
+    letter-spacing: normal;
 }
 
 .hx\:sm\:text-xl {
-      font-size: var(--hx-text-xl);
-      line-height: var(--tw-leading, var(--hx-text-xl--line-height));
-      margin-bottom: 2em;
+    font-size: var(--hx-text-2xl);
+    line-height: var(--tw-leading, var(--hx-text-2xl--line-height));
+    margin-bottom: 2em;
+    font-variant: all-small-caps;
+    letter-spacing: normal;
 }
 
 @media (max-width: 768px) {
@@ -77,6 +77,9 @@ strong {
     font-size: unset;
   }
   .content :where(h3):not(:where([class~=not-prose],[class~=not-prose] *)) {
+    font-size: unset;
+  }
+  .content :where(h4):not(:where([class~=not-prose],[class~=not-prose] *)) {
     font-size: unset;
   }
 }

--- a/content/_index.md
+++ b/content/_index.md
@@ -7,7 +7,7 @@ toc: false
 ---
 
 {{< hextra/hero-headline >}}
-Explore Remastered Bible Texts &    
+Explore Remastered Bible Texts and    
 Classic Christian Writings
 {{< /hextra/hero-headline >}}
 

--- a/content/the-gospel.md
+++ b/content/the-gospel.md
@@ -11,7 +11,7 @@ linkTitle: "The Gospel"
 
 The Gospel, meaning "Good News," is the transformative message of God's love, forgiveness, and hope through Jesus Christ. It is the Good News that offers eternal life to all who believe. Continue reading below to explore further insights into this powerful message.
 
-## God, Lord & Creator
+## God, Lord and Creator
 
 God made us to know, love and serve Him. Jesus Christ, the eternal one, created all things and rules over all.
 
@@ -121,7 +121,7 @@ We cannot save ourselves by good works or moral reform.
 > *Therefore no one will be justified in His sight by works of the law. For the law merely brings awareness of sin.*   
 > &mdash; Romans 3:20, BSB
 
-## Jesus, Lord & Savior
+## Jesus, Lord and Savior
 
 God who is rich in mercy and love for us sent His Son, Jesus Christ, who lived a righteous and perfect life and died in our place to pay for our sins and rose again.
 


### PR DESCRIPTION
- Minor adjustment to original criteria: instead of replicating the font-variant of all small caps on all headers, all headers will use the default font-variant with the exception of the titles on the home page
- Home page title and sub title use the font-variant of all-small-caps in addition to having letter spacing adjusted to normal for consistent presentation